### PR TITLE
Optional passing of SSLSocketFactory

### DIFF
--- a/default.properties
+++ b/default.properties
@@ -1,1 +1,1 @@
-target=android-3
+target=android-1.6

--- a/local.properties.dist
+++ b/local.properties.dist
@@ -1,1 +1,1 @@
-sdk.dir=/usr/local/android_sdk/
+sdk.dir=/android-sdk-mac/

--- a/src/com/loopj/android/http/AsyncHttpClient.java
+++ b/src/com/loopj/android/http/AsyncHttpClient.java
@@ -20,11 +20,11 @@ package com.loopj.android.http;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
+import java.lang.ref.WeakReference;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
-import java.lang.ref.WeakReference;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -39,13 +39,12 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.CookieStore;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.protocol.ClientContext;
 import org.apache.http.conn.params.ConnManagerParams;
 import org.apache.http.conn.params.ConnPerRouteBean;
@@ -60,8 +59,8 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpProtocolParams;
 import org.apache.http.protocol.BasicHttpContext;
-import org.apache.http.protocol.SyncBasicHttpContext;
 import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.SyncBasicHttpContext;
 
 import android.content.Context;
 
@@ -106,6 +105,10 @@ public class AsyncHttpClient {
      * @param userAgent the identifier to use in the User-Agent header in requests
      */
     public AsyncHttpClient(String userAgent) {
+    	new AsyncHttpClient(userAgent, null);
+    }
+    
+    public AsyncHttpClient(String userAgent, SSLSocketFactory sslSocketFactory) {
         BasicHttpParams httpParams = new BasicHttpParams();
 
         ConnManagerParams.setTimeout(httpParams, socketTimeout);
@@ -120,7 +123,11 @@ public class AsyncHttpClient {
 
         SchemeRegistry schemeRegistry = new SchemeRegistry();
         schemeRegistry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
-        schemeRegistry.register(new Scheme("https", SSLSocketFactory.getSocketFactory(), 443));
+        
+        if (sslSocketFactory == null) {
+        	sslSocketFactory = SSLSocketFactory.getSocketFactory();
+        }
+        schemeRegistry.register(new Scheme("https", sslSocketFactory, 443));
         ThreadSafeClientConnManager cm = new ThreadSafeClientConnManager(httpParams, schemeRegistry);
 
         httpContext = new SyncBasicHttpContext(new BasicHttpContext());


### PR DESCRIPTION
I thought it might be helpful to add support for passing in an SSLSocketFactory to the AsyncHttpClient constructor. I was able to create a custom SSLSocketFactory that handles my trusted certs and pass it in without having to do too much to your existing code.

BTW - This lib is awesome! Saved me a bit of time from writing this all from scratch.
