### PR TITLE
Uploading multiple files through multipart form post is broken

### DIFF
--- a/src/com/loopj/android/http/RequestParams.java
+++ b/src/com/loopj/android/http/RequestParams.java
@@ -187,15 +187,19 @@ public class RequestParams {
             }
 
             // Add file params
+            int currentIndex = 0;
+            int lastIndex = fileParams.entrySet().size() - 1;
             for(ConcurrentHashMap.Entry<String, FileWrapper> entry : fileParams.entrySet()) {
                 FileWrapper file = entry.getValue();
                 if(file.inputStream != null) {
+                	boolean isLast = currentIndex == lastIndex;
                     if(file.contentType != null) {
-                        multipartEntity.addPart(entry.getKey(), file.getFileName(), file.inputStream, file.contentType);
+                        multipartEntity.addPart(entry.getKey(), file.getFileName(), file.inputStream, file.contentType, isLast);
                     } else {
-                        multipartEntity.addPart(entry.getKey(), file.getFileName(), file.inputStream);
+                        multipartEntity.addPart(entry.getKey(), file.getFileName(), file.inputStream, isLast);
                     }
                 }
+                currentIndex++;
             }
 
             entity = multipartEntity;

--- a/src/com/loopj/android/http/SimpleMultipartEntity.java
+++ b/src/com/loopj/android/http/SimpleMultipartEntity.java
@@ -93,11 +93,11 @@ class SimpleMultipartEntity implements HttpEntity {
         }
     }
 
-    public void addPart(final String key, final String fileName, final InputStream fin){
-        addPart(key, fileName, fin, "application/octet-stream");
+    public void addPart(final String key, final String fileName, final InputStream fin, final boolean isLast){
+        addPart(key, fileName, fin, "application/octet-stream", isLast);
     }
 
-    public void addPart(final String key, final String fileName, final InputStream fin, String type){
+    public void addPart(final String key, final String fileName, final InputStream fin, String type, final boolean isLast){
         writeFirstBoundaryIfNeeds();
         try {
             type = "Content-Type: "+type+"\r\n";
@@ -110,6 +110,8 @@ class SimpleMultipartEntity implements HttpEntity {
             while ((l = fin.read(tmp)) != -1) {
                 out.write(tmp, 0, l);
             }
+            if(!isLast)
+            	out.write(("\r\n--" + boundary + "\r\n").getBytes());
             out.flush();
         } catch (final IOException e) {
             e.printStackTrace();
@@ -122,9 +124,9 @@ class SimpleMultipartEntity implements HttpEntity {
         }
     }
 
-    public void addPart(final String key, final File value) {
+    public void addPart(final String key, final File value, final boolean isLast) {
         try {
-            addPart(key, value.getName(), new FileInputStream(value));
+            addPart(key, value.getName(), new FileInputStream(value), isLast);
         } catch (final FileNotFoundException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
I tried uploading two files using a multipart form post but found that only one was ever getting through.  Upon further inspection, the problem was that there was no boundary being set in between files and that the second one was just mashed in after the first.  This commit fixes this by adding a boundary in between every file that isn't the very last one.  After the last one the normal last boundary is written.
