### PR TITLE
issue #6 fix - canceling requests

### DIFF
--- a/src/com/loopj/android/http/AsyncHttpRequest.java
+++ b/src/com/loopj/android/http/AsyncHttpRequest.java
@@ -59,12 +59,18 @@ class AsyncHttpRequest implements Runnable {
             }
         }
     }
-
+    
     private void makeRequest() throws IOException {
-        HttpResponse response = client.execute(request, context);
-        if(responseHandler != null) {
-            responseHandler.sendResponseMessage(response);
-        }
+    	if(!Thread.currentThread().isInterrupted()) {
+    		HttpResponse response = client.execute(request, context);
+    		if(!Thread.currentThread().isInterrupted()) {
+    			if(responseHandler != null) {
+    				responseHandler.sendResponseMessage(response);
+    			}
+    		} else{
+    			//TODO: should raise InterruptedException? this block is reached whenever the request is cancelled before its response is received
+    		}
+    	}
     }
 
     private void makeRequestWithRetries() throws ConnectException {
@@ -86,7 +92,7 @@ class AsyncHttpRequest implements Runnable {
                 // http://code.google.com/p/android/issues/detail?id=5255
                 cause = new IOException("NPE in HttpClient" + e.getMessage());
                 retry = retryHandler.retryRequest(cause, ++executionCount, context);
-            }
+            } 
         }
 
         // no retries left, crap out with exception


### PR DESCRIPTION
Regarding issue #6 - canceling requests 
https://github.com/loopj/android-async-http/issues/6

Added xpapazaf code to check for thread interruption at the request class
