### PR TITLE
allow RequestParams to be used independently in 3rd party packages

### DIFF
--- a/src/com/loopj/android/http/RequestParams.java
+++ b/src/com/loopj/android/http/RequestParams.java
@@ -174,8 +174,11 @@ public class RequestParams {
 
         return result.toString();
     }
-
-    HttpEntity getEntity() {
+ 
+   /**
+     * Returns an HttpEntity containing all request parameters
+     */
+    public HttpEntity getEntity() {
         HttpEntity entity = null;
 
         if(!fileParams.isEmpty()) {


### PR DESCRIPTION
One small change required: making RequestParams.getEntity() public instead of package-private
