### PR TITLE
Adding method to set an 'Authorization' header

### DIFF
--- a/src/com/loopj/android/http/AsyncHttpClient.java
+++ b/src/com/loopj/android/http/AsyncHttpClient.java
@@ -231,6 +231,23 @@ public class AsyncHttpClient {
     }
 
     /**
+     * Sets the "Authorization" HTTP header set in the request objects made by 
+     * the HTTP client to a token-based authentication value, such as an OAuth access token. 
+     * This overwrites any existing value for this header.
+     * @param token The authentication token
+     */
+    public void setAuthorizationHeader(String token){
+    	clientHeaderMap.put("Authorization", String.format("Token token=\"%s\"", token));
+    }
+    
+    /**
+     * Clears any existing value for the "Authorization" HTTP header.
+     */
+    public void clearAuthorizationHeader(){
+    	clientHeaderMap.remove("Authorization");
+    }
+
+    /**
      * Cancels any pending (or potentially active) requests associated with the
      * passed Context.
      * <p>


### PR DESCRIPTION
Simple yet useful change that adds a method to set a basic 'Authorization' HTTP header that can be used in a token-based authentication service.
