### PR TITLE
Set default charset to UTF-8 in AsyncHttpResponseHandler

### DIFF
--- a/src/com/loopj/android/http/AsyncHttpResponseHandler.java
+++ b/src/com/loopj/android/http/AsyncHttpResponseHandler.java
@@ -211,7 +211,7 @@ public class AsyncHttpResponseHandler {
             HttpEntity temp = response.getEntity();
             if(temp != null) {
                 entity = new BufferedHttpEntity(temp);
-                responseBody = EntityUtils.toString(entity);
+                responseBody = EntityUtils.toString(entity, "UTF-8");
             }
         } catch(IOException e) {
             sendFailureMessage(e, null);


### PR DESCRIPTION
`EntityUtils.toString(entity)` defaults to ISO-8859-1, which is pretty inconvenient and rarely desired in modern APIs commonly encountered by Android apps. This pull request changes the default to UTF-8, which strikes me as a more common case. If deemed appropriate, I can rework this to keep the current default encoding and make it easier to override (maintaining reverse-compatibility), but this is a more sensible default.

Cf. http://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/util/EntityUtils.html#toString(org.apache.http.HttpEntity)
