### PR TITLE
Fix for issue #62

### DIFF
--- a/src/com/loopj/android/http/JsonHttpResponseHandler.java
+++ b/src/com/loopj/android/http/JsonHttpResponseHandler.java
@@ -89,7 +89,6 @@ public class JsonHttpResponseHandler extends AsyncHttpResponseHandler {
 
     @Override
     protected void handleFailureMessage(Throwable e, String responseBody) {
-        super.handleFailureMessage(e, responseBody);
         if (responseBody != null) try {
             Object jsonResponse = parseResponse(responseBody);
             if(jsonResponse instanceof JSONObject) {


### PR DESCRIPTION
onFailure(Throwable e, String responseBody) is not called twice from handleFailureMessage. Closes #62
