### PR TITLE
Allow more than one Request param with the same key.

### DIFF
--- a/local.properties.dist
+++ b/local.properties.dist
@@ -1,1 +1,0 @@
-sdk.dir=/usr/local/android_sdk/

--- a/src/com/loopj/android/http/RequestParams.java
+++ b/src/com/loopj/android/http/RequestParams.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +58,7 @@ public class RequestParams {
 
     protected ConcurrentHashMap<String, String> urlParams;
     protected ConcurrentHashMap<String, FileWrapper> fileParams;
+    protected ConcurrentHashMap<String, ArrayList<String>> urlParamsWithArray;
 
     /**
      * Constructs a new empty <code>RequestParams</code> instance.
@@ -111,6 +113,17 @@ public class RequestParams {
     }
 
     /**
+     * Adds param with more than one value.
+     * @param key the key name for the new param.
+     * @param values is the ArrayList with values for the param.
+     */
+    public void put(String key, ArrayList<String> values)  {
+        if(key != null && values != null) {
+            urlParamsWithArray.put(key, values);
+        }
+    }
+
+    /**
      * Adds an input stream to the request.
      * @param key the key name for the new param.
      * @param stream the input stream to add.
@@ -149,6 +162,7 @@ public class RequestParams {
     public void remove(String key){
         urlParams.remove(key);
         fileParams.remove(key);
+        urlParamsWithArray.remove(key);
     }
 
     @Override
@@ -170,6 +184,20 @@ public class RequestParams {
             result.append(entry.getKey());
             result.append("=");
             result.append("FILE");
+        }
+
+        for(ConcurrentHashMap.Entry<String, ArrayList<String>> entry : urlParamsWithArray.entrySet()) {
+            if(result.length() > 0)
+                result.append("&");
+
+            ArrayList<String> values = entry.getValue();
+            for (String value : values) {
+                if (values.indexOf(value) != 0)
+                    result.append("&");
+                result.append(entry.getKey());
+                result.append("=");
+                result.append(value);
+            }
         }
 
         return result.toString();
@@ -205,6 +233,14 @@ public class RequestParams {
                 currentIndex++;
             }
 
+            // Add dupe params
+            for(ConcurrentHashMap.Entry<String, ArrayList<String>> entry : urlParamsWithArray.entrySet()) {
+                ArrayList<String> values = entry.getValue();
+                for (String value : values) {
+                    multipartEntity.addPart(entry.getKey(), value);
+                }
+            }
+
             entity = multipartEntity;
         } else {
             try {
@@ -220,6 +256,7 @@ public class RequestParams {
     private void init(){
         urlParams = new ConcurrentHashMap<String, String>();
         fileParams = new ConcurrentHashMap<String, FileWrapper>();
+        urlParamsWithArray = new ConcurrentHashMap<String, ArrayList<String>>();
     }
 
     protected List<BasicNameValuePair> getParamsList() {
@@ -227,6 +264,13 @@ public class RequestParams {
 
         for(ConcurrentHashMap.Entry<String, String> entry : urlParams.entrySet()) {
             lparams.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
+        }
+
+        for(ConcurrentHashMap.Entry<String, ArrayList<String>> entry : urlParamsWithArray.entrySet()) {
+            ArrayList<String> values = entry.getValue();
+            for (String value : values) {
+                lparams.add(new BasicNameValuePair(entry.getKey(), value));
+            }
         }
 
         return lparams;


### PR DESCRIPTION
Many services allow a param to be added to a request multiple times, ie:

https://www.myfakeservice.com/this/is/a/test?param=fakeparam&param=anotherfakeparam/

There was no way that I could decipher in the original code to do this so I added new put methods to take a key and an ArrayList of Strings for the values. Now all you would need to do is something like this:

RequestParams params = new RequestParams();
ArrayList<String> dupParam = new ArrayList<String>();
            dupParam.add("ONE");
            dupParam.add("TWO");
            params.put("numbers", dupParam);
