### PR TITLE
added an onFailure if there is a problem with the remote host or the internet connection

### DIFF
--- a/src/com/loopj/android/http/AsyncHttpRequest.java
+++ b/src/com/loopj/android/http/AsyncHttpRequest.java
@@ -20,6 +20,7 @@ package com.loopj.android.http;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.UnknownHostException;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpRequestRetryHandler;
@@ -91,6 +92,11 @@ class AsyncHttpRequest implements Runnable {
             try {
                 makeRequest();
                 return;
+	    } catch (UnknownHostException e) {
+	        if(responseHandler != null) {
+	            responseHandler.sendFailureMessage(e, "can't resolve host");
+		}
+		return;
             } catch (IOException e) {
                 cause = e;
                 retry = retryHandler.retryRequest(cause, ++executionCount, context);

--- a/src/com/loopj/android/http/JsonHttpResponseHandler.java
+++ b/src/com/loopj/android/http/JsonHttpResponseHandler.java
@@ -78,7 +78,13 @@ public class JsonHttpResponseHandler extends AsyncHttpResponseHandler {
     }
 
     protected Object parseResponse(String responseBody) throws JSONException {
-        return new JSONTokener(responseBody).nextValue();
+        Object result = null;
+        //trim the string to prevent start with blank, and test if the string is valid JSON, because the parser don't do this :(. If Json is not valid this will return null
+	responseBody = responseBody.trim();
+	if(responseBody.startsWith("{") || responseBody.startsWith("[")) {
+	    result = new JSONTokener(responseBody).nextValue();
+	}
+	return result;
     }
 
     /**
@@ -89,19 +95,21 @@ public class JsonHttpResponseHandler extends AsyncHttpResponseHandler {
 
     @Override
     protected void handleFailureMessage(Throwable e, String responseBody) {
-        if (responseBody != null) try {
-            Object jsonResponse = parseResponse(responseBody);
-            if(jsonResponse instanceof JSONObject) {
-                onFailure(e, (JSONObject)jsonResponse);
-            } else if(jsonResponse instanceof JSONArray) {
-                onFailure(e, (JSONArray)jsonResponse);
+        try {
+            if (responseBody != null) {
+                Object jsonResponse = parseResponse(responseBody);
+                if(jsonResponse instanceof JSONObject) {
+                    onFailure(e, (JSONObject)jsonResponse);
+                } else if(jsonResponse instanceof JSONArray) {
+                    onFailure(e, (JSONArray)jsonResponse);
+                } else {
+                    onFailure(e, responseBody);
+                }
+            }else {
+                onFailure(e, "");
             }
-        }
-        catch(JSONException ex) {
+        }catch(JSONException ex) {
             onFailure(e, responseBody);
-        }
-        else {
-            onFailure(e, "");
         }
     }
 }


### PR DESCRIPTION
Hello,

I added some verifications in your project to be sure that the remote host is available ( this is not the case if you loose internet connection or if the host is really down)

that way if you send a Json request, you can catch the message in 
public void onFailure(Throwable e, String errorResponse)

I also added a further check in the Jsonformat.
Indeed a valid Json should start with { or with [ 
It seams that this is not checked in the JSONTokener function.
if the String is not a valid json, it will return null

So i also modified the handleFailureMessage to include that case
