### PR TITLE
Added POST method to take HttpEntity

### DIFF
--- a/src/com/loopj/android/http/AsyncHttpClient.java
+++ b/src/com/loopj/android/http/AsyncHttpClient.java
@@ -409,9 +409,7 @@ public class AsyncHttpClient {
      * @param context the Android Context which initiated the request.
      * @param url the URL to send the request to.
      * @param headers set headers only for this request
-     * @param entity a raw {@link HttpEntity} to send with the request, for
-     *        example, use this to send string/json/xml payloads to a server by
-     *        passing a {@link org.apache.http.entity.StringEntity}.
+     * @param params additional POST parameters to send with the request.
      * @param contentType the content type of the payload you are sending, for
      *        example application/json if sending a json payload.
      * @param responseHandler the response handler instance that should handle
@@ -424,6 +422,28 @@ public class AsyncHttpClient {
         if(headers != null) request.setHeaders(headers);
         sendRequest(httpClient, httpContext, request, contentType,
                 responseHandler, context);
+    }
+
+    /**
+     * Perform a HTTP POST request and track the Android Context which initiated
+     * the request. Set headers only for this request
+     *
+     * @param context the Android Context which initiated the request.
+     * @param url the URL to send the request to.
+     * @param headers set headers only for this request
+     * @param entity a raw {@link HttpEntity} to send with the request, for
+     *        example, use this to send string/json/xml payloads to a server by
+     *        passing a {@link org.apache.http.entity.StringEntity}.
+     * @param contentType the content type of the payload you are sending, for
+     *        example application/json if sending a json payload.
+     * @param responseHandler the response handler instance that should handle
+     *        the response.
+     */
+    public void post(Context context, String url, Header[] headers, HttpEntity entity, String contentType,
+            AsyncHttpResponseHandler responseHandler) {
+        HttpEntityEnclosingRequestBase request = addEntityToRequestBase(new HttpPost(url), entity);
+        if(headers != null) request.setHeaders(headers);
+        sendRequest(httpClient, httpContext, request, contentType, responseHandler, context);
     }
 
     //


### PR DESCRIPTION
I've added a method that will take an HttpEntity along with an array of Headers. It looks like the version that now takes a RequestParams object originally did this as the comment-block for it still referred to HttpEntity so I've amended that (and appropriately commented the new method).
