### PR TITLE
Modified handleFailureMessage to handle string-only response.

### DIFF
--- a/src/com/loopj/android/http/JsonHttpResponseHandler.java
+++ b/src/com/loopj/android/http/JsonHttpResponseHandler.java
@@ -96,8 +96,8 @@ public class JsonHttpResponseHandler extends AsyncHttpResponseHandler {
             } else if(jsonResponse instanceof JSONArray) {
                 onFailure(e, (JSONArray)jsonResponse);
             } else if(jsonResponse instanceof String) {
-		onFailure(e, (String)jsonResponse);
-	    }
+                onFailure(e, (String)jsonResponse);
+            }
         }
         catch(JSONException ex) {
             onFailure(e, responseBody);


### PR DESCRIPTION
In cases where the server's response is, for instance "Unauthorized", this method currently ignores the message as it is not a JSONObject or a JSONArray. A string /is/ a valid JSON value though, legitimately returned by JSONTokener (so no exceptions are thrown and we therefore get no feedback on what went wrong). I have therefore added an extra else-if branch to call onFailure(Throwable, String) in the parent class for such situations.
