### PR TITLE
Overloaded RequestParams.put() method for adding integer param

### DIFF
--- a/src/com/loopj/android/http/RequestParams.java
+++ b/src/com/loopj/android/http/RequestParams.java
@@ -100,6 +100,17 @@ public class RequestParams {
             urlParams.put(key, value);
         }
     }
+    
+    /**
+     * Adds a integer param to the request.
+     * @param key the key name for the new param.
+     * @param value the integer value for the new param.
+     */
+    public void put(String key, int value){
+        if(key != null) {
+            urlParams.put(key, String.valueOf(value));
+        }
+    }
 
     /**
      * Adds a file to the request.


### PR DESCRIPTION
Hi,

There is no put() method for adding integer param without casting it to string before passing as an argument to `put(String arg0, String arg1)`

It would be much easier to pass straight integer value.

Before:
`put("ParamName", String.valueOf(1234));`

After:
`put("ParamName", 1234);`

Patch attached.
