### PR TITLE
Fix a NullPointerException in JsonHttpResponseHandler if response is not json type

### DIFF
--- a/src/com/loopj/android/http/JsonHttpResponseHandler.java
+++ b/src/com/loopj/android/http/JsonHttpResponseHandler.java
@@ -108,11 +108,14 @@ public class JsonHttpResponseHandler extends AsyncHttpResponseHandler {
     protected Object parseResponse(String responseBody) throws JSONException {
         Object result = null;
         //trim the string to prevent start with blank, and test if the string is valid JSON, because the parser don't do this :(. If Json is not valid this will return null
-	responseBody = responseBody.trim();
-	if(responseBody.startsWith("{") || responseBody.startsWith("[")) {
-	    result = new JSONTokener(responseBody).nextValue();
-	}
-	return result;
+		responseBody = responseBody.trim();
+		if(responseBody.startsWith("{") || responseBody.startsWith("[")) {
+			result = new JSONTokener(responseBody).nextValue();
+		}
+		if (result == null) {
+			result = responseBody;
+		}
+		return result;
     }
 
     @Override


### PR DESCRIPTION
If result is null after new JSONTokener(result) which means response is
not a json type, assign result to responseBody to avoid making
NullPointerException and also makes handleSuccessJsonMessage able to
create a JSONException with right jsonResponse's class name.
