### PR TITLE
AsyncHttpRequest don't send failure message for BinaryHttpResponseHandler in case UnknownHostException

### DIFF
--- a/src/com/loopj/android/http/AsyncHttpRequest.java
+++ b/src/com/loopj/android/http/AsyncHttpRequest.java
@@ -93,8 +93,12 @@ class AsyncHttpRequest implements Runnable {
                 makeRequest();
                 return;
 	    } catch (UnknownHostException e) {
-	        if(responseHandler != null) {
-	            responseHandler.sendFailureMessage(e, "can't resolve host");
+            if(responseHandler != null) {
+                if(this.isBinaryRequest) {
+                    responseHandler.sendFailureMessage(e, (byte[]) null);
+                } else {
+                    responseHandler.sendFailureMessage(e, "can't resolve host");
+                }
 		}
 		return;
             } catch (IOException e) {


### PR DESCRIPTION
Hi, loopj!

If Android device is out of range or has no network service, AsyncHttpRequest catches UnknownHostException.
However AsyncHttpRequest don't send the failure message for BinaryHttpResponseHandler.
