### PR TITLE
Fix Issue 23: Forever loop while host is not found

### DIFF
--- a/src/com/loopj/android/http/AsyncHttpRequest.java
+++ b/src/com/loopj/android/http/AsyncHttpRequest.java
@@ -20,6 +20,7 @@ package com.loopj.android.http;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 
 import org.apache.http.HttpResponse;
@@ -92,11 +93,17 @@ class AsyncHttpRequest implements Runnable {
             try {
                 makeRequest();
                 return;
-	    } catch (UnknownHostException e) {
-	        if(responseHandler != null) {
-	            responseHandler.sendFailureMessage(e, "can't resolve host");
-		}
-		return;
+            } catch (UnknownHostException e) {
+		        if(responseHandler != null) {
+		            responseHandler.sendFailureMessage(e, "can't resolve host");
+		        }
+	        	return;
+            }catch (SocketException e){
+                // Added to detect host unreachable
+                if(responseHandler != null) {
+                    responseHandler.sendFailureMessage(e, "can't resolve host");
+                }
+                return;
             } catch (IOException e) {
                 cause = e;
                 retry = retryHandler.retryRequest(cause, ++executionCount, context);


### PR DESCRIPTION
Hey loopj! Like your work!

This adds a quick SocketException catch in `AsyncHttpRequest.makeRequestWithRetries` to resolve the responseHandler not getting sent a FailureResponse when the host is unreachable. IMO this is a critically important, and simple, fix.

There's a related [SO](http://stackoverflow.com/questions/12866353/loopj-android-async-http-onfailure-not-fired) question you may want to put to rest if you confirm this fixes the issue.
