### PR TITLE
getUrlWithQueryString

### DIFF
--- a/src/com/loopj/android/http/AsyncHttpClient.java
+++ b/src/com/loopj/android/http/AsyncHttpClient.java
@@ -572,7 +572,11 @@ public class AsyncHttpClient {
     public static String getUrlWithQueryString(String url, RequestParams params) {
         if(params != null) {
             String paramString = params.getParamString();
-            url += "?" + paramString;
+            if (url.indexOf("?") == -1) {
+                url += "?" + paramString;
+            } else {
+                url += "&" + paramString;
+            }
         }
 
         return url;


### PR DESCRIPTION
fix in getUrlWithQueryString to append additional parameters in url with
query string already present
