### PR TITLE
Fixed connection hang when host unreachable

### DIFF
--- a/src/com/loopj/android/http/RetryHandler.java
+++ b/src/com/loopj/android/http/RetryHandler.java
@@ -28,12 +28,13 @@ import java.io.InterruptedIOException;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.HashSet;
+import java.util.Iterator;
 
 import javax.net.ssl.SSLHandshakeException;
 
 import org.apache.http.NoHttpResponseException;
-import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HttpContext;
 
@@ -73,10 +74,10 @@ class RetryHandler implements HttpRequestRetryHandler {
         if(executionCount > maxRetries) {
             // Do not retry if over max retry count
             retry = false;
-        } else if (exceptionBlacklist.contains(exception.getClass())) {
+        } else if (isInList(exceptionBlacklist, exception)) {
             // immediately cancel retry if the error is blacklisted
             retry = false;
-        } else if (exceptionWhitelist.contains(exception.getClass())) {
+        } else if (isInList(exceptionWhitelist, exception)) {
             // immediately retry if error is whitelisted
             retry = true;
         } else if (!sent) {
@@ -98,5 +99,15 @@ class RetryHandler implements HttpRequestRetryHandler {
         }
 
         return retry;
+    }
+    
+    protected boolean isInList(HashSet<Class<?>> list, Throwable error) {
+    	Iterator<Class<?>> itr = list.iterator();
+    	while (itr.hasNext()) {
+    		if (itr.next().isInstance(error)) {
+    			return true;
+    		}
+    	}
+    	return false;
     }
 }


### PR DESCRIPTION
Fixed: Exception black/white list in RetryHandler not checked against child classes like ConnectTimeoutException, causing connection hang when the destination is unreachable.
