### PR TITLE
Support same cookie-name for multiple domain!

### DIFF
--- a/src/com/loopj/android/http/PersistentCookieStore.java
+++ b/src/com/loopj/android/http/PersistentCookieStore.java
@@ -80,7 +80,7 @@ public class PersistentCookieStore implements CookieStore {
 
     @Override
     public void addCookie(Cookie cookie) {
-        String name = cookie.getName();
+        String name = cookie.getName() + cookie.getDomain();
 
         // Save cookie into local store, or remove if expired
         if(!cookie.isExpired(new Date())) {


### PR DESCRIPTION
As of now, the library assumes that the name of the cookie would be unique. So if there are 2 domains using the same cookie name, one of them is compromised!

Changed the key for storing cookie to `cookie.getName() + cookie.getDomain()`
