### PR TITLE
Use obtain instead of new on Message creation to improve memory efficiency.

### DIFF
--- a/src/com/loopj/android/http/AsyncHttpResponseHandler.java
+++ b/src/com/loopj/android/http/AsyncHttpResponseHandler.java
@@ -209,7 +209,7 @@ public class AsyncHttpResponseHandler {
         if(handler != null){
             msg = this.handler.obtainMessage(responseMessage, response);
         }else{
-            msg = new Message();
+            msg = Message.obtain();
             msg.what = responseMessage;
             msg.obj = response;
         }


### PR DESCRIPTION
Hey,James 
I found the obtainMessage() use a directly new , which could be improved by calling the recommended Message.obtain. 
http://developer.android.com/reference/android/os/Message.html#obtain()
Hope it help a little to improve:)

Thanks,
Chang
