### PR TITLE
Fix creating entity with dupe and file params

### DIFF
--- a/src/com/loopj/android/http/RequestParams.java
+++ b/src/com/loopj/android/http/RequestParams.java
@@ -236,6 +236,14 @@ public class RequestParams {
                 multipartEntity.addPart(entry.getKey(), entry.getValue());
             }
 
+            // Add dupe params
+            for(ConcurrentHashMap.Entry<String, ArrayList<String>> entry : urlParamsWithArray.entrySet()) {
+                ArrayList<String> values = entry.getValue();
+                for (String value : values) {
+                    multipartEntity.addPart(entry.getKey(), value);
+                }
+            }
+
             // Add file params
             int currentIndex = 0;
             int lastIndex = fileParams.entrySet().size() - 1;
@@ -250,14 +258,6 @@ public class RequestParams {
                     }
                 }
                 currentIndex++;
-            }
-
-            // Add dupe params
-            for(ConcurrentHashMap.Entry<String, ArrayList<String>> entry : urlParamsWithArray.entrySet()) {
-                ArrayList<String> values = entry.getValue();
-                for (String value : values) {
-                    multipartEntity.addPart(entry.getKey(), value);
-                }
             }
 
             entity = multipartEntity;


### PR DESCRIPTION
A boundary will not be written after the last file params. If there are additional dupe params, they do not get added to the entity properly. Switching the order and adding the file params last fixes this issue.
