### PR TITLE
Add protected access modifier to fields in SyncHttpClient

### DIFF
--- a/src/com/loopj/android/http/SyncHttpClient.java
+++ b/src/com/loopj/android/http/SyncHttpClient.java
@@ -14,8 +14,8 @@ public abstract class SyncHttpClient extends AsyncHttpClient {
 	 * the result back to this method. Therefore the result object has to be a
 	 * field to be accessible
 	 */
-	private String result;
-	AsyncHttpResponseHandler responseHandler = new AsyncHttpResponseHandler() {
+	protected String result;
+	protected AsyncHttpResponseHandler responseHandler = new AsyncHttpResponseHandler() {
 
 		void sendResponseMessage(org.apache.http.HttpResponse response) {
 			responseCode = response.getStatusLine().getStatusCode();


### PR DESCRIPTION
Change the access modifiers to protected for the _result_ field and
_responseHandler_ field in the SyncHttpClient class
