### PR TITLE
BinaryHttpResponseHandler.java: handleMessage cast eror on FAILURE_MESSAGE management

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,6 +4,5 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="src" path="examples"/>
-	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>


### PR DESCRIPTION
Hi loopj,
in BinaryHttpResponseHandler there seems to be an invalid cast when a byte array is sent as second parameter to handleFailureMessage(), while a String is expected and a string is actually received in that case in msg.obj.response[1].

Thanks, and keep up the good work
Luca
