### PR TITLE
Use regular expression to match content type in BinaryResponseHandler

### DIFF
--- a/src/com/loopj/android/http/BinaryHttpResponseHandler.java
+++ b/src/com/loopj/android/http/BinaryHttpResponseHandler.java
@@ -19,6 +19,7 @@
 package com.loopj.android.http;
 
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -168,7 +169,7 @@ public class BinaryHttpResponseHandler extends AsyncHttpResponseHandler {
         Header contentTypeHeader = contentTypeHeaders[0];
         boolean foundAllowedContentType = false;
         for(String anAllowedContentType : mAllowedContentTypes) {
-            if(anAllowedContentType.equals(contentTypeHeader.getValue())) {
+            if(Pattern.matches(anAllowedContentType, contentTypeHeader.getValue())) {
                 foundAllowedContentType = true;
             }
         }


### PR DESCRIPTION
This allows the developer a bit more flexibility in picking which content types to allow. This is fully backwards compatible. 

For example, to all downloading of all file types:

``` java
private static final String[] ALLOWED_CONTENT_TYPES = {".*"};

AsyncHttpResponseHandler responseHandler = new BinaryResponseHandler(ALLOWED_CONTENT_TYPES) {
   @Override
   public void onSuccess(int statusCode, byte[] data) {
      ...
   }
}
```
