### PR TITLE
Fix Bug (java.lang.ClassCastException: String cannot be cast to byte[])

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,5 +4,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="src" path="examples"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/src/com/loopj/android/http/BinaryHttpResponseHandler.java
+++ b/src/com/loopj/android/http/BinaryHttpResponseHandler.java
@@ -143,7 +143,7 @@ public class BinaryHttpResponseHandler extends AsyncHttpResponseHandler {
         switch(msg.what) {
             case SUCCESS_MESSAGE:
                 response = (Object[])msg.obj;
-                handleSuccessMessage(((Integer) response[0]).intValue() , (byte[]) response[1]);
+                handleSuccessMessage(((Integer) response[0]).intValue(), response[1].toString().getBytes());
                 break;
             case FAILURE_MESSAGE:
                 response = (Object[])msg.obj;


### PR DESCRIPTION
This bug occurs with BinaryHttpResponseHandler when failed to download
data. (at
BinaryHttpResponseHandler.handleMessage(BinaryHttpResponseHandler.java:145))
