### PR TITLE
add content-type parameter for char-stream data in multipart/form-data & fix bug of writing wrong last boundary

### DIFF
--- a/src/com/loopj/android/http/SimpleMultipartEntity.java
+++ b/src/com/loopj/android/http/SimpleMultipartEntity.java
@@ -77,20 +77,30 @@ class SimpleMultipartEntity implements HttpEntity {
             return;
         }
 
-        writeBoundary();
+        try {
+            out.write(("--" + boundary + "--\r\n").getBytes());
+            out.flush();
+        } catch (final IOException e) {
+            e.printStackTrace();
+        }
         
         isSetLast = true;
     }
 
-    public void addPart(final String key, final String value) {
+    public void addPart(final String key, final String value, final String contentType) {
         writeBoundary();
         try {
-            out.write(("Content-Disposition: form-data; name=\"" +key+"\"\r\n\r\n").getBytes());
+            out.write(("Content-Disposition: form-data; name=\"" +key+"\"\r\n").getBytes());
+            out.write(("Content-Type: " + contentType + "\r\n\r\n").getBytes());
             out.write(value.getBytes());
             out.write(("\r\n").getBytes());
         } catch (final IOException e) {
             e.printStackTrace();
         }
+    }
+
+    public void addPart(final String key, final String value) {
+        addPart(key,value,"text/plain; charset=UTF-8");
     }
 
     public void addPart(final String key, final String fileName, final InputStream fin, final boolean isLast){
@@ -111,7 +121,7 @@ class SimpleMultipartEntity implements HttpEntity {
                 out.write(tmp, 0, l);
             }
             out.write(("\r\n").getBytes());
-            out.flush();
+            
         } catch (final IOException e) {
             e.printStackTrace();
         } finally {
@@ -159,6 +169,7 @@ class SimpleMultipartEntity implements HttpEntity {
 
     @Override
     public void writeTo(final OutputStream outstream) throws IOException {
+        writeLastBoundaryIfNeeds();
         outstream.write(out.toByteArray());
     }
 
@@ -179,6 +190,7 @@ class SimpleMultipartEntity implements HttpEntity {
     @Override
     public InputStream getContent() throws IOException,
     UnsupportedOperationException {
+    	writeLastBoundaryIfNeeds();
         return new ByteArrayInputStream(out.toByteArray());
     }
 }


### PR DESCRIPTION
1. when I modify the code mentioned in #226. I find it writes wrong last boundary ("--XXXXX" instead of "--XXXX--").
2. add `Content-Type` for text parameters in multipart/form-data request for supporting utf-8 characters such as Chinese
