### PR TITLE
Fix for java.lang.ClassCastException in BinaryHttpResponseHandler

### DIFF
--- a/src/com/loopj/android/http/BinaryHttpResponseHandler.java
+++ b/src/com/loopj/android/http/BinaryHttpResponseHandler.java
@@ -143,11 +143,17 @@ public class BinaryHttpResponseHandler extends AsyncHttpResponseHandler {
         switch(msg.what) {
             case SUCCESS_MESSAGE:
                 response = (Object[])msg.obj;
-                handleSuccessMessage(((Integer) response[0]).intValue() , (byte[]) response[1]);
+                if (response[1] instanceof String) {
+                  handleFailureMessage(new HttpResponseException(((Integer) response[0]).intValue(),
+                      "String cannot be cast to byte[]"), response.toString());
+                } else {
+                  handleSuccessMessage(((Integer) response[0]).intValue() , (byte[]) response[1]);
+                }
                 break;
             case FAILURE_MESSAGE:
                 response = (Object[])msg.obj;
-                handleFailureMessage((Throwable)response[0], response[1].toString());
+                String res1 = response[1] == null ? "" : response[1].toString();
+                handleFailureMessage((Throwable) response[0], res1);
                 break;
             default:
                 super.handleMessage(msg);


### PR DESCRIPTION
I've got loads of `ClassCastException` crash reports and this commit might fix the bug.
I'm not yet sure of why this bug exists in the first place.
Please confirm this and let me know if I'm doing something wrong here.
Thanks

``` java
java.lang.ClassCastException: java.lang.String cannot be cast to byte[]
  at com.loopj.android.http.BinaryHttpResponseHandler.handleMessage(BinaryHttpResponseHandler.java:145)
  at com.loopj.android.http.AsyncHttpResponseHandler$1.handleMessage(AsyncHttpResponseHandler.java:84)
```
