### PR TITLE
Fixing handling a failure message in BinaryResponseHttpResponseHandler.

### DIFF
--- a/src/com/loopj/android/http/BinaryHttpResponseHandler.java
+++ b/src/com/loopj/android/http/BinaryHttpResponseHandler.java
@@ -147,7 +147,7 @@ public class BinaryHttpResponseHandler extends AsyncHttpResponseHandler {
                 break;
             case FAILURE_MESSAGE:
                 response = (Object[])msg.obj;
-                handleFailureMessage((Throwable)response[0], response[1].toString());
+                handleFailureMessage((Throwable)response[0], response[1] != null ? response[1].toString() : null);
                 break;
             default:
                 super.handleMessage(msg);


### PR DESCRIPTION
There are several cases where we send a failure message with null data
in the BinaryResponseHttpResponseHandler (notably, when we're checking
the content type).  This causes a NPE when we try to call toString(), so
the client never has the chance to offer the error.

There's another fix (5ff9e695538a493317d5887bde962c2a4149dcab) that
address this, but I prefer this one for two reasons:
1) null, as dastardly as it is, is preferable to returning an empty
string in this error case, as the response body may be valid but empty.
2) That patch also includes a fix to cast responses to String, which
shouldn't ever be valid with a BinaryHttpResponseHandler.  We're only
dealing with byte arrays, right?
