### PR TITLE
Should convert reponse[1] to byte[] instead of String in handleMessage.

### DIFF
--- a/src/com/loopj/android/http/BinaryHttpResponseHandler.java
+++ b/src/com/loopj/android/http/BinaryHttpResponseHandler.java
@@ -147,7 +147,7 @@ public class BinaryHttpResponseHandler extends AsyncHttpResponseHandler {
                 break;
             case FAILURE_MESSAGE:
                 response = (Object[])msg.obj;
-                handleFailureMessage((Throwable)response[0], response[1].toString());
+                handleFailureMessage((Throwable)response[0], (byte[]) response[1]);
                 break;
             default:
                 super.handleMessage(msg);


### PR DESCRIPTION
line 189:
sendFailureMessage(e, (byte[]) null);

line 150:
handleFailureMessage((Throwable)response[0], (byte[]) response[1]);
in some situation, response[1] can be null, so that response[1].toString() will throw exception.

furthormore, convert reponse[1] to String will let AsyncHttpResponseHandler::handleFailureMessage be invoked instead of BinaryHttpResponseHandler::handleFailureMessage.
