### PR TITLE
The failure message should have the response in a byte array.

### DIFF
--- a/src/com/loopj/android/http/BinaryHttpResponseHandler.java
+++ b/src/com/loopj/android/http/BinaryHttpResponseHandler.java
@@ -147,7 +147,7 @@ public class BinaryHttpResponseHandler extends AsyncHttpResponseHandler {
                 break;
             case FAILURE_MESSAGE:
                 response = (Object[])msg.obj;
-                handleFailureMessage((Throwable)response[0], response[1].toString());
+                handleFailureMessage((Throwable)response[0], (byte[]) response[1]);
                 break;
             default:
                 super.handleMessage(msg);


### PR DESCRIPTION
handleSuccessMessage() was being (properly) handed a byte array, but handleFailureMessage() was being passed a string. This adjusts the call to handleFailureMessage() to pass a byte array as well.
