### PR TITLE
Response string charset option

### DIFF
--- a/src/com/loopj/android/http/AsyncHttpResponseHandler.java
+++ b/src/com/loopj/android/http/AsyncHttpResponseHandler.java
@@ -213,6 +213,12 @@ public class AsyncHttpResponseHandler {
         }
     }
 
+   /**
+   * Sets the charset for the response string. If not set, the default is UTF-8.
+   * @see <a href="http://docs.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html">Charset</a>
+   *
+   * @param charset to be used for the response string.
+   */
     public void setCharset(final String charset) {
         this.charset = charset;
     }


### PR DESCRIPTION
The XML response of the web service I need is encoded in ISO-8859-1. I experienced false characters with no way for me to handle or convert the response string properly since UTF-8 is hardcoded. The charset has to be set when the response string is built.

I simply added a class variable for the charset to the AsyncHttpResponseHandler. The default is still UTF-8, but now there's an option to set the charset via a setter. I did not add another constructor with a charset-string as a parameter (yet?) to keep it simple.
