### PR TITLE
Fix crash in RetryHandler

### DIFF
--- a/src/com/loopj/android/http/RetryHandler.java
+++ b/src/com/loopj/android/http/RetryHandler.java
@@ -89,7 +89,7 @@ class RetryHandler implements HttpRequestRetryHandler {
         if(retry) {
             // resend all idempotent requests
             HttpUriRequest currentReq = (HttpUriRequest) context.getAttribute( ExecutionContext.HTTP_REQUEST );
-            String requestType = currentReq.getMethod();
+            String requestType = currentReq != null ? currentReq.getMethod() : "";
             retry = !requestType.equals("POST");
         }
 
@@ -101,7 +101,7 @@ class RetryHandler implements HttpRequestRetryHandler {
 
         return retry;
     }
-    
+
     protected boolean isInList(HashSet<Class<?>> list, Throwable error) {
     	Iterator<Class<?>> itr = list.iterator();
     	while (itr.hasNext()) {


### PR DESCRIPTION
It is possible for context.getAttribute(...) to return null,
so we have to check currentReq before we call getMethod() on it.

Without this fix the HttpClient seems to hang forever and
onFinish() is never called in the AsyncHttpHandlers.
