### PR TITLE
added HEAD request capabilities

### DIFF
--- a/src/com/loopj/android/http/AsyncHttpClient.java
+++ b/src/com/loopj/android/http/AsyncHttpClient.java
@@ -45,6 +45,7 @@ import org.apache.http.client.CookieStore;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
@@ -296,6 +297,68 @@ public class AsyncHttpClient {
     }
 
 
+    //
+    // HTTP HEAD Requests
+    //
+
+    /**
+     * Perform a HTTP HEAD request, without any parameters.
+     * @param url the URL to send the request to.
+     * @param responseHandler the response handler instance that should handle the response.
+     */
+    public void head(String url, AsyncHttpResponseHandler responseHandler) {
+        head(null, url, null, responseHandler);
+    }
+
+    /**
+     * Perform a HTTP HEAD request with parameters.
+     * @param url the URL to send the request to.
+     * @param params additional HEAD parameters to send with the request.
+     * @param responseHandler the response handler instance that should handle the response.
+     */
+    public void head(String url, RequestParams params, AsyncHttpResponseHandler responseHandler) {
+        head(null, url, params, responseHandler);
+    }
+
+    /**
+     * Perform a HTTP HEAD request without any parameters and track the Android Context which initiated the request.
+     * @param context the Android Context which initiated the request.
+     * @param url the URL to send the request to.
+     * @param responseHandler the response handler instance that should handle the response.
+     */
+    public void head(Context context, String url, AsyncHttpResponseHandler responseHandler) {
+        head(context, url, null, responseHandler);
+    }
+
+    /**
+     * Perform a HTTP HEAD request and track the Android Context which initiated the request.
+     * @param context the Android Context which initiated the request.
+     * @param url the URL to send the request to.
+     * @param params additional HEAD parameters to send with the request.
+     * @param responseHandler the response handler instance that should handle the response.
+     */
+    public void head(Context context, String url, RequestParams params, AsyncHttpResponseHandler responseHandler) {
+        sendRequest(httpClient, httpContext, new HttpHead(getUrlWithQueryString(url, params)), null, responseHandler, context);
+    }
+    
+    /**
+     * Perform a HTTP HEAD request and track the Android Context which initiated
+     * the request with customized headers
+     * 
+     * @param url the URL to send the request to.
+     * @param headers set headers only for this request
+     * @param params additional HEAD parameters to send with the request.
+     * @param responseHandler the response handler instance that should handle
+     *        the response.
+     */
+    public void head(Context context, String url, Header[] headers, RequestParams params, AsyncHttpResponseHandler responseHandler) {
+        HttpUriRequest request = new HttpHead(getUrlWithQueryString(url, params));
+        if(headers != null) request.setHeaders(headers);
+        sendRequest(httpClient, httpContext, request, null, responseHandler,
+                context);
+    }
+    
+    
     //
     // HTTP GET Requests
     //


### PR DESCRIPTION
addresses issue https://github.com/loopj/android-async-http/issues/146

sample: 

added to TwitterRestClient as seen in the [docs](http://loopj.com/android-async-http/):

``` java
import com.loopj.android.http.*;

public class TwitterRestClient {
  private static final String BASE_URL = "http://api.twitter.com/1/";

  private static AsyncHttpClient client = new AsyncHttpClient();

  //
  //new
  public static void head(final String url, final RequestParams params, final AsyncHttpResponseHandler responseHandler) {
      client.head(getAbsoluteUrl(url), params, responseHandler);
  }
  //new
  //

  public static void get(String url, RequestParams params, AsyncHttpResponseHandler responseHandler) {
      client.get(getAbsoluteUrl(url), params, responseHandler);
  }

  public static void post(String url, RequestParams params, AsyncHttpResponseHandler responseHandler) {
      client.post(getAbsoluteUrl(url), params, responseHandler);
  }

  private static String getAbsoluteUrl(String relativeUrl) {
      return BASE_URL + relativeUrl;
  }
}

```

usage:

``` java
TwitterRestClient.head("statuses/public_timeline.json", null, new AsyncHttpResponseHandler() {
     @Override
     public void onSuccess(int statusCode, Header[] headers, String content) {
          System.out.println("----header start----");
          for(final Header h : headers) {
               System.out.println(h.getName() + ":" + h.getValue());
          }
          System.out.println("----header finish----");
     }
});
```
