### PR TITLE
fix empty response bug in JsonHttpResponseHandler

### DIFF
--- a/src/com/loopj/android/http/JsonHttpResponseHandler.java
+++ b/src/com/loopj/android/http/JsonHttpResponseHandler.java
@@ -126,7 +126,7 @@ public class JsonHttpResponseHandler extends AsyncHttpResponseHandler {
     	        sendFailureMessage(e, responseBody);
     	    }
         } else {
-            sendMessage(obtainMessage(SUCCESS_JSON_MESSAGE, new Object[]{statusCode, new JSONObject()}));
+            sendMessage(obtainMessage(SUCCESS_JSON_MESSAGE, new Object[]{statusCode, headers, new JSONObject()}));
     	}
     }
 


### PR DESCRIPTION
Fixes a cast exception on line 143, when response is empty.
