### PR TITLE
Correct POM_NAME

### DIFF
--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -1,3 +1,3 @@
-POM_NAME=ActionBar-PullToRefresh Library
+POM_NAME=android-async-http Library
 POM_ARTIFACT_ID=android-async-http
 POM_PACKAGING=aar


### PR DESCRIPTION
`library/gradle.properties` was still using `ActionBar-PullToRefresh` as `POM_NAME`, so the name in the [pom in maven central](http://search.maven.org/#artifactdetails%7Ccom.loopj.android%7Candroid-async-http%7C1.4.3%7Cjar) is actually wrong right now.
