### PR TITLE
ArtifactID should be 'android-async-http' in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ http://central.maven.org/maven2/com/loopj/android/android-async-http/
 ```
 Maven URL: http://repo1.maven.org/maven2/
 GroupId: com.loopj.android
-ArtifactId: async-http-client
+ArtifactId: android-async-http
 Version: 1.4.3
 Packaging: JAR or AAR
 ```


### PR DESCRIPTION
I was trying to compile from Maven using 
'com.loopj.android:async-http-client:1.4.3'
which doesn't work. It should be:
'com.loopj.android:android-async-http:1.4.3'
