### PR TITLE
fix bug: upload more than 2 files in a single post request will be failed

### DIFF
--- a/library/src/main/java/com/loopj/android/http/SimpleMultipartEntity.java
+++ b/library/src/main/java/com/loopj/android/http/SimpleMultipartEntity.java
@@ -190,7 +190,7 @@ class SimpleMultipartEntity implements HttpEntity {
         }
 
         public long getTotalLength() {
-            long streamLength = file.length();
+            long streamLength = file.length() + CR_LF.length;
             return header.length + streamLength;
         }
 


### PR DESCRIPTION
In the function getTotalLength, the length of a single file lost 2 bytes because of the CR_LF.
When uploading 1 file in a single post request, lost 2 bytes, the CR_LF will not be sent.
When uploading 2 file in a single post request, lost 4 bytes, the substring in file split "--" will not be sent.
When uploading more than 2 file in a single post request, lost more than 4 bytes, the last file split will not be complete any more. The server will show an error.
