### PR TITLE
Don't use weak reference for ResponderHandler

### DIFF
--- a/library/src/main/java/com/loopj/android/http/AsyncHttpResponseHandler.java
+++ b/library/src/main/java/com/loopj/android/http/AsyncHttpResponseHandler.java
@@ -124,17 +124,16 @@ public abstract class AsyncHttpResponseHandler implements ResponseHandlerInterfa
      * Avoid leaks by using a non-anonymous handler class with a weak reference
      */
     static class ResponderHandler extends Handler {
-        private final WeakReference<AsyncHttpResponseHandler> mResponder;
+        private final AsyncHttpResponseHandler mResponder;
 
         ResponderHandler(AsyncHttpResponseHandler service) {
-            mResponder = new WeakReference<AsyncHttpResponseHandler>(service);
+            mResponder =service;
         }
 
         @Override
         public void handleMessage(Message msg) {
-            AsyncHttpResponseHandler service = mResponder.get();
-            if (null != service) {
-                service.handleMessage(msg);
+            if (mResponder != null) {
+        	mResponder.handleMessage(msg);
             }
         }
     }


### PR DESCRIPTION
Fixed issue #430 issue, #367  etc.

The AsyncHttpResponseHandler should not be a weak reference,it will be gc when memory is low,so we can't get any responses from library.
