### PR TITLE
Run on current thread if no looper is present in Async response

### DIFF
--- a/library/src/main/java/com/loopj/android/http/AsyncHttpResponseHandler.java
+++ b/library/src/main/java/com/loopj/android/http/AsyncHttpResponseHandler.java
@@ -30,8 +30,6 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.util.ByteArrayBuffer;
 
-import com.heyzap.http.AsyncHttpResponseHandler.ResponderHandler;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;


### PR DESCRIPTION
The implementation before essentially means that you can't use this library from short-lived threads. It also starts a looper on a thread not owned by the HTTP library, which is unexpected.

1) What it would effectively mean is that if you wanted to make an HTTP request from a short-lived thread, you would never receive a response. The expectation of an Async library is that even if the parent thread dies, you would still receive a response.
2) Declaring a looper inside is very problematic and unexpected behavior.

The following fix does the following:
- If there is a looper present, the runnable will be run on that thread. Thus, for long-lived threads, you can expect the runnable to be executed on the calling thread.
- If the looper is not present, the runnable will be run on the current thread (I assume a thread from the current HTTP thread pool).
