### PR TITLE
Use indexes for array parameters

### DIFF
--- a/library/src/main/java/com/loopj/android/http/RequestParams.java
+++ b/library/src/main/java/com/loopj/android/http/RequestParams.java
@@ -512,12 +512,14 @@ public class RequestParams {
             }
         } else if (value instanceof List) {
             List list = (List) value;
-            for (int nestedValueIndex = 0; nestedValueIndex < list.size(); nestedValueIndex++) {
+            int listSize = list.size();
+            for (int nestedValueIndex = 0; nestedValueIndex < listSize; nestedValueIndex++) {
                 params.addAll(getParamsList(String.format("%s[%d]", key, nestedValueIndex), list.get(nestedValueIndex)));
             }
         } else if (value instanceof Object[]) {
             Object[] array = (Object[]) value;
-            for (int nestedValueIndex = 0; nestedValueIndex < array.length; nestedValueIndex++) {
+            int arrayLength = array.length;
+            for (int nestedValueIndex = 0; nestedValueIndex < arrayLength; nestedValueIndex++) {
                 params.addAll(getParamsList(String.format("%s[%d]", key, nestedValueIndex), array[nestedValueIndex]));
             }
         } else if (value instanceof Set) {


### PR DESCRIPTION
Serializing an array which contains other arrays/maps gives incorrect results.

```
param = [
    { "foo1" => "bar1", "foo2" => "bar2" },
    { "foo1" => "bar1", "foo2" => "bar2" },
]
```

Should produce

```
param[0][foo1] = bar1
param[0][foo2] = bar2
param[1][foo1] = bar1
param[1][foo2] = bar2
```

Instead of

```
param[][foo1] = bar1
param[][foo2] = bar2
param[][foo1] = bar1
param[][foo2] = bar2
```
