### PR TITLE
Cast params to string by default

### DIFF
--- a/library/src/main/java/com/loopj/android/http/RequestParams.java
+++ b/library/src/main/java/com/loopj/android/http/RequestParams.java
@@ -525,8 +525,8 @@ public class RequestParams {
             for (Object nestedValue : set) {
                 params.addAll(getParamsList(key, nestedValue));
             }
-        } else if (value instanceof String) {
-            params.add(new BasicNameValuePair(key, (String) value));
+        } else {
+            params.add(new BasicNameValuePair(key, value.toString()));
         }
         return params;
     }


### PR DESCRIPTION
```
RequestParams params = new RequestParams();
params.put( "number", new Integer( 1 ) );
```

isn't working at the moment since `Integer` types are ignored when generating the params list.

I think the library should accept other types by casting them to string.
