### PR TITLE
fix an exception

### DIFF
--- a/library/src/main/java/com/loopj/android/http/AsyncHttpRequest.java
+++ b/library/src/main/java/com/loopj/android/http/AsyncHttpRequest.java
@@ -167,7 +167,12 @@ public class AsyncHttpRequest implements Runnable {
     public boolean cancel(boolean mayInterruptIfRunning) {
         isCancelled = true;
         if (mayInterruptIfRunning && request != null && !request.isAborted()) {
-            request.abort();
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    request.abort();
+                }
+            });
         }
         return isCancelled();
     }


### PR DESCRIPTION
Fix NetworkonmainthreadException occurs when AsyncHttpRequest.cancel(true) is called.

```
android.os.NetworkOnMainThreadException
at android.os.StrictMode$AndroidBlockGuardPolicy.onNetwork(StrictMode.java:1117)
at org.apache.harmony.xnet.provider.jsse.OpenSSLSocketImpl.close(OpenSSLSocketImpl.java:908)
at org.apache.http.impl.SocketHttpClientConnection.shutdown(SocketHttpClientConnection.java:183)
at org.apache.http.impl.conn.DefaultClientConnection.shutdown(DefaultClientConnection.java:150)
at org.apache.http.impl.conn.AbstractPooledConnAdapter.shutdown(AbstractPooledConnAdapter.java:169)
at org.apache.http.impl.conn.AbstractClientConnAdapter.abortConnection(AbstractClientConnAdapter.java:378)
at org.apache.http.client.methods.HttpRequestBase.abort(HttpRequestBase.java:159)
at com.loopj.android.http.AsyncHttpRequest.cancel(AsyncHttpRequest.java:170)
at com.loopj.android.http.RequestHandle.cancel(RequestHandle.java:32)
at com.loopj.android.http.AsyncHttpClient.cancelRequests(AsyncHttpClient.java:565)
```
