### PR TITLE
remove the overwritten header in AsyncHttpClient  constructor

### DIFF
--- a/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java
+++ b/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java
@@ -255,6 +255,9 @@ public class AsyncHttpClient {
                                         header, clientHeaderMap.get(header),
                                         overwritten.getName(), overwritten.getValue())
                         );
+                        
+                        //remove the overwritten header
+                        request.removeHeader(overwritten);
                     }
                     request.addHeader(header, clientHeaderMap.get(header));
                 }


### PR DESCRIPTION
when I call addHeader to change "Content-Type" header,the  issue emerges.

like this:

POST /xampp/ HTTP/1.1
Content-Length: 99
Content-Type: application/x-www-form-urlencoded
Host: 192.168.22.199
Connection: Keep-Alive
Accept-Encoding: gzip
Content-Type: application/json 
